### PR TITLE
fix: replace attrdict

### DIFF
--- a/hpman/hpm_db.py
+++ b/hpman/hpm_db.py
@@ -1,10 +1,8 @@
+import ast
 import collections
 import enum
 import functools
-import ast
-from typing import Callable, Dict, List, Optional, Union, DefaultDict, Any
-
-from attrdict import AttrDict  # type: ignore
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Union
 
 from .primitives import DoubleAssignmentException, EmptyValue
 from .source_helper import SourceHelper
@@ -17,6 +15,12 @@ class HyperParameterPriority(enum.IntEnum):
 
 
 P = HyperParameterPriority
+
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
 
 
 class HyperParameterOccurrence(AttrDict):

--- a/hpman/m.py
+++ b/hpman/m.py
@@ -1,0 +1,2 @@
+# Placeholder file to solve `MissingImports`.
+# See `hpm.py` for real code details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-attrdict


### PR DESCRIPTION
- For `attrdict`, the original library is now no longer maintained and there are some warning on `python3.7`.  
So I replaced it with reference to [accessing-dict-keys-like-an-attribute](https://stackoverflow.com/questions/4984647/accessing-dict-keys-like-an-attribute)

All tests pass for `python3.7` and `python3.6`, also work fine in internal projects.

**Warning**:  on `python3.9` and upper, some tests fail:
<details>
<summary>test shell log</summary>
<pre>
λ ~/Developer/git/hpman/ master python3.9 -m pytest
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/jinyu/Developer/git/hpman
plugins: anyio-2.0.2, cov-3.0.0
collected 44 items                                                                                                                                                                        

tests/test_callable.py ......                                                                                                                                                       [ 13%]
tests/test_hpm_db.py .........                                                                                                                                                      [ 34%]
tests/test_hpm_zoo.py .                                                                                                                                                             [ 36%]
tests/test_parse_file.py .....                                                                                                                                                      [ 47%]
tests/test_parse_source.py ....F........F....                                                                                                                                       [ 88%]
tests/test_setget.py ...                                                                                                                                                            [ 95%]
tests/test_source_helper.py ..                                                                                                                                                      [100%]

======================================================================================== FAILURES =========================================================================================
____________________________________________________________________________ TestParseSource.test_parse_hints _____________________________________________________________________________

self = <test_parse_source.TestParseSource testMethod=test_parse_hints>
test_datas = {"_('hp0', 1, a=1, b=2, c={'d': 3, 'e': 4})": ['hp0', 1, <class 'ast.Num'>, {'a': 1, 'b': 2, 'c': {'d': 3, 'e': 4}}], ...a=[1, 3, 4], b=2, c={'d': 3, 'e': 4})": ['hp1', 1, <class 'ast.Num'>, {'a': [1, 3, 4], 'b': 2, 'c': {'d': 3, 'e': 4}}]}

    def _run(self, test_datas):
        """test_data spec:
            {
                '_(key, value)': [
                    key, value
                ],
                ...
            }
        """
        try:
            for expression, kv in test_datas.items():
                name = kv[0]
                value = kv[1]
                ast_node_type = kv[2]
    
                m = self.hpm.parse_source(expression)
                # check default value
                if isinstance(value, hpman.NotLiteralEvaluable):
                    self.assertEqual(type(m.get_value(name)), hpman.NotLiteralEvaluable)
                else:
                    self.assertEqual(m.get_value(name), value)
    
                # check ast node type
>               self.assertEqual(
                    type(m.get_occurrence_of_value(name)["ast_node"]), ast_node_type
                )

tests/test_parse_source.py:227: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_parse_source.TestParseSource testMethod=test_parse_hints>, first = <class 'ast.Constant'>, second = <class 'ast.Num'>, msg = None

    def assertEqual(self, first, second, msg=None):
        """Fail if the two objects are unequal as determined by the '=='
           operator.
        """
        assertion_func = self._getAssertEqualityFunc(first, second)
>       assertion_func(first, second, msg=msg)

/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:837: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_parse_source.TestParseSource testMethod=test_parse_hints>, first = <class 'ast.Constant'>, second = <class 'ast.Num'>, msg = "<class 'ast.Constant'> != <class 'ast.Num'>"

    def _baseAssertEqual(self, first, second, msg=None):
        """The default assertEqual implementation, not type specific."""
        if not first == second:
            standardMsg = '%s != %s' % _common_shorten_repr(first, second)
            msg = self._formatMessage(msg, standardMsg)
>           raise self.failureException(msg)
E           AssertionError: <class 'ast.Constant'> != <class 'ast.Num'>

/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:830: AssertionError

During handling of the above exception, another exception occurred:

self = <test_parse_source.TestParseSource testMethod=test_parse_hints>

    def test_parse_hints(self):
>       self._run(
            {
                "_('hp0', 1, a=1, b=2, c={'d': 3, 'e': 4})": [
                    "hp0",
                    1,
                    ast.Num,
                    {"a": 1, "b": 2, "c": {"d": 3, "e": 4}},
                ],
                "_('hp1', 1, a=[1, 3, 4], b=2, c={'d': 3, 'e': 4})": [
                    "hp1",
                    1,
                    ast.Num,
                    {"a": [1, 3, 4], "b": 2, "c": {"d": 3, "e": 4}},
                ],
            }
        )

tests/test_parse_source.py:34: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_parse_source.py:237: in _run
    self.fail("parse failed with exception: {}".format(e))
E   AssertionError: parse failed with exception: <class 'ast.Constant'> != <class 'ast.Num'>
________________________________________________________________________ TestParseSource.test_parse_type_with_pod _________________________________________________________________________

self = <test_parse_source.TestParseSource testMethod=test_parse_type_with_pod>
test_datas = {"_('hp_float', 3.14)": ['hp_float', 3.14, <class 'ast.Num'>], "_('hp_float_ieee', 1e-5)": ['hp_float_ieee', 1e-05, <c...p_int', 123)": ['hp_int', 123, <class 'ast.Num'>], "_('hp_int_hex', 0x18)": ['hp_int_hex', 24, <class 'ast.Num'>], ...}

    def _run(self, test_datas):
        """test_data spec:
            {
                '_(key, value)': [
                    key, value
                ],
                ...
            }
        """
        try:
            for expression, kv in test_datas.items():
                name = kv[0]
                value = kv[1]
                ast_node_type = kv[2]
    
                m = self.hpm.parse_source(expression)
                # check default value
                if isinstance(value, hpman.NotLiteralEvaluable):
                    self.assertEqual(type(m.get_value(name)), hpman.NotLiteralEvaluable)
                else:
                    self.assertEqual(m.get_value(name), value)
    
                # check ast node type
>               self.assertEqual(
                    type(m.get_occurrence_of_value(name)["ast_node"]), ast_node_type
                )

tests/test_parse_source.py:227: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_parse_source.TestParseSource testMethod=test_parse_type_with_pod>, first = <class 'ast.Constant'>, second = <class 'ast.Num'>, msg = None

    def assertEqual(self, first, second, msg=None):
        """Fail if the two objects are unequal as determined by the '=='
           operator.
        """
        assertion_func = self._getAssertEqualityFunc(first, second)
>       assertion_func(first, second, msg=msg)

/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:837: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_parse_source.TestParseSource testMethod=test_parse_type_with_pod>, first = <class 'ast.Constant'>, second = <class 'ast.Num'>
msg = "<class 'ast.Constant'> != <class 'ast.Num'>"

    def _baseAssertEqual(self, first, second, msg=None):
        """The default assertEqual implementation, not type specific."""
        if not first == second:
            standardMsg = '%s != %s' % _common_shorten_repr(first, second)
            msg = self._formatMessage(msg, standardMsg)
>           raise self.failureException(msg)
E           AssertionError: <class 'ast.Constant'> != <class 'ast.Num'>

/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py:830: AssertionError

During handling of the above exception, another exception occurred:

self = <test_parse_source.TestParseSource testMethod=test_parse_type_with_pod>

    def test_parse_type_with_pod(self):
>       self._run(
            {
                "_('hp_int', 123)": ["hp_int", 123, ast.Num],
                "_('hp_int_hex', 0x18)": ["hp_int_hex", 0x18, ast.Num],
                "_('hp_float', 3.14)": ["hp_float", 3.14, ast.Num],
                "_('hp_float_ieee', 1e-5)": ["hp_float_ieee", 1e-5, ast.Num],
                "_('hp_str', 'string')": ["hp_str", "string", ast.Str],
            }
        )

tests/test_parse_source.py:23: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_parse_source.py:237: in _run
    self.fail("parse failed with exception: {}".format(e))
E   AssertionError: parse failed with exception: <class 'ast.Constant'> != <class 'ast.Num'>
================================================================================= short test summary info =================================================================================
FAILED tests/test_parse_source.py::TestParseSource::test_parse_hints - AssertionError: parse failed with exception: <class 'ast.Constant'> != <class 'ast.Num'>
FAILED tests/test_parse_source.py::TestParseSource::test_parse_type_with_pod - AssertionError: parse failed with exception: <class 'ast.Constant'> != <class 'ast.Num'>
============================================================================== 2 failed, 42 passed in 0.43s ===============================================================================
</pre>
</details>