### PR TITLE
Allow multiple occurrence when they have a same value

### DIFF
--- a/hpman/hpm_db.py
+++ b/hpman/hpm_db.py
@@ -158,7 +158,7 @@ class HyperParamNode:
             if not item.priority == P.PRIORITY_PARSED_FROM_SOURCE_CODE:
                 continue
 
-            if item.has_default_value:
+            if item.has_default_value and item.value != occ.value:
                 error_msg = (
                     "Duplicated default values:\n"
                     "First occurrence:\n"


### PR DESCRIPTION
Hi, thanks for such useful work! I have found it very convenient to manage hyperparameters, except the prohibition of multiple occurrence. 

Actually in most usage scenarios, the user may want to copy and rename a file to add more features while remain the previous experiments unchanged. In such case the double assignment error might be raised if there were default values set in the origin file, which requires the user to delete all these default values in the new file by hand even if these values are the same. This is very inconvenient.

This PR offers a way to avoid such problem when these default values are the same. I suppose this would make the user experience much better.